### PR TITLE
Sets accessibleFields for all fields by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ $data = [
 		/**
 		 * The _entityOptions array is passed to Table::newEntity() and
 		 * Table::patchEntity(). It can be used to disable validation.
+		 *
+		 * Also be aware that the Shell sets
+		 * `['accessibleFields' => ['*' => true]]` by default in order to
+		 * more easily "prime" new Entities with all of the values
+		 * specified in $data, including fixed primary keys. This bypasses
+		 * your normal Entity `::$_accessible` settings, so it's good to
+		 * be aware of this if you're using a seed to "refresh" existing
+		 * data.
 		 */
 		//'_entityOptions' => [
 		//	'validate' => false,

--- a/src/Shell/BasicSeedShell.php
+++ b/src/Shell/BasicSeedShell.php
@@ -185,6 +185,7 @@ class BasicSeedShell extends Shell {
 	) {
 		$defaultOptions = [
 			'validate' => true,
+			'accessibleFields' => ['*' => true],
 		];
 		$options = $options + $defaultOptions;
 
@@ -204,8 +205,7 @@ class BasicSeedShell extends Shell {
 					}
 
 				} else {
-					$entity = $Table->newEntity([], $options);
-					$entity->set($r, ['guard' => false]);
+					$entity = $Table->newEntity($r, $options);
 					$entity->isNew(true);
 				}
 
@@ -217,7 +217,7 @@ class BasicSeedShell extends Shell {
 			if ($errors) {
 				$this->printValidationErrors(
 					$Table->alias(),
-					$key,
+					$id,
 					$errors
 				);
 
@@ -241,6 +241,7 @@ class BasicSeedShell extends Shell {
 	public function importTable(Table $Table, $records, array $options = []) {
 		$defaultOptions = [
 			'checkRules' => true,
+			'checkExisting' => true,
 		];
 		$options = $options + $defaultOptions;
 


### PR DESCRIPTION
This change makes it easier for the Shell to inject new DB records with a pre-defined primary key field from the seed data. This is essential if you are manually building up relationships between tables.

Fixes #14 
